### PR TITLE
Feature: Add Rails and Foreman support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,13 +57,22 @@ program
   .option("-p, --port <port>", "Development server port", "3000")
   .option("--mcp-port <port>", "MCP server port", "3684")
   .option("-s, --script <script>", "Package.json script to run (e.g. dev, build-start)", "dev")
+  .option("--server-command <command>", "Custom server command (overrides --script)")
   .option("--profile-dir <dir>", "Chrome profile directory", join(tmpdir(), "dev3000-chrome-profile"))
+  .option("--framework <framework>", "Framework for error detection (nextjs, rails, auto)", "auto")
+  .option("--process-manager <manager>", "Process manager for log parsing (standard, foreman, auto)", "auto")
   .option("--servers-only", "Run servers only, skip browser launch (use with Chrome extension)")
   .option("--debug", "Enable debug logging to console")
   .action(async (options) => {
-    // Convert script option to full command
-    const packageManager = detectPackageManager()
-    const serverCommand = `${packageManager} run ${options.script}`
+    // Use custom server command if provided, otherwise use script
+    let serverCommand: string;
+    if (options.serverCommand) {
+      serverCommand = options.serverCommand;
+    } else {
+      // Convert script option to full command
+      const packageManager = detectPackageManager();
+      serverCommand = `${packageManager} run ${options.script}`;
+    }
 
     // Detect which command name was used (dev3000 or d3k)
     const executablePath = process.argv[1]

--- a/src/dev-environment.ts
+++ b/src/dev-environment.ts
@@ -19,7 +19,7 @@ import { tmpdir } from "os";
 import { basename, dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { CDPMonitor } from "./cdp-monitor.js";
-import { OutputProcessor, LogEntry, StandardLogParser, NextJsErrorDetector } from "./services/parsers/index.js";
+import { OutputProcessor, LogEntry, OutputProcessorFactory, ProcessManagerOption, FrameworkOption } from "./services/parsers/index.js";
 
 interface DevEnvironmentOptions {
   port: string;
@@ -27,6 +27,8 @@ interface DevEnvironmentOptions {
   serverCommand: string;
   profileDir: string;
   logFile: string;
+  framework?: string;
+  processManager?: string;
   debug?: boolean;
   serversOnly?: boolean;
   commandName: string;
@@ -162,9 +164,10 @@ export class DevEnvironment {
   constructor(options: DevEnvironmentOptions) {
     this.options = options;
     this.logger = new Logger(options.logFile);
-    this.outputProcessor = new OutputProcessor(
-      new StandardLogParser(),
-      new NextJsErrorDetector()
+    this.outputProcessor = OutputProcessorFactory.create(
+      options.serverCommand,
+      options.processManager as ProcessManagerOption || 'auto',
+      options.framework as FrameworkOption || 'auto'
     );
 
     // Set up MCP server public directory for web-accessible screenshots

--- a/src/services/parsers/error-detectors/base.ts
+++ b/src/services/parsers/error-detectors/base.ts
@@ -1,0 +1,65 @@
+/**
+ * Base interfaces and types for error detectors
+ * Responsible for identifying critical errors in server output
+ */
+
+/**
+ * Base interface for error detectors
+ * Responsible for determining if a message indicates a critical error
+ */
+export interface ErrorDetector {
+  /**
+   * Check if a message indicates a critical error
+   * @param message The raw message to check
+   * @returns true if the message indicates a critical error
+   */
+  isCritical(message: string): boolean;
+}
+
+/**
+ * Base error detector with common error patterns
+ * Provides a foundation that specific framework detectors can extend
+ */
+export class BaseErrorDetector implements ErrorDetector {
+  isCritical(message: string): boolean {
+    // Common critical error patterns across all frameworks
+    const criticalPatterns = [
+      // Connection and port errors
+      /EADDRINUSE/,                   // Port already in use
+      /EACCES/,                       // Permission denied
+      /ENOENT/,                       // File not found
+      /ECONNREFUSED/,                 // Connection refused
+      
+      // System-level errors
+      /out of memory/i,               // Memory issues
+      /segmentation fault/i,          // Segfaults
+      /stack overflow/i,              // Stack overflows
+      
+      // Generic fatal errors
+      /FATAL/,                        // Fatal errors
+      /PANIC/,                        // Panic conditions
+      /SIGKILL/,                      // Process killed
+      /SIGTERM/,                      // Process terminated
+      
+      // Module/dependency errors (but exclude warnings)
+      /Cannot find module(?!.*warning)/,      // Missing modules (exclude warnings)
+      /Module not found(?!.*warning)/,        // Missing modules (exclude warnings)
+      /Package not found(?!.*warning)/,       // Missing packages (exclude warnings)
+      
+      // Syntax and parsing errors (but exclude warnings)
+      /SyntaxError(?!.*warning)/,             // Syntax errors (exclude warnings)
+      /Parse error(?!.*warning)/,             // Parse errors (exclude warnings)
+      /Unexpected token(?!.*warning)/,        // Parsing issues (exclude warnings)
+    ];
+    
+    // Early return false for obvious non-critical patterns to avoid regex overhead
+    if (/warning/i.test(message) || 
+        /WARN/.test(message) || 
+        /deprecated/i.test(message)) {
+      return false;
+    }
+    
+    // Check for critical patterns
+    return criticalPatterns.some(pattern => pattern.test(message));
+  }
+}

--- a/src/services/parsers/error-detectors/factory.ts
+++ b/src/services/parsers/error-detectors/factory.ts
@@ -1,0 +1,33 @@
+/**
+ * Factory for creating error detectors
+ * Pure factory - only handles object creation
+ */
+
+import { ErrorDetector, NextJsErrorDetector, RailsErrorDetector } from './index.js';
+
+/**
+ * Supported frameworks for error detection
+ */
+export type Framework = 'nextjs' | 'rails';
+
+/**
+ * Simple factory for creating error detectors
+ * No auto-detection logic - just creates the right detector for the given framework
+ */
+export class ErrorDetectorFactory {
+  /**
+   * Create an error detector for the specified framework
+   * @param framework The framework type (must be explicit)
+   * @returns An ErrorDetector instance
+   */
+  static create(framework: Framework): ErrorDetector {
+    switch (framework) {
+      case 'rails':
+        return new RailsErrorDetector();
+      case 'nextjs':
+        return new NextJsErrorDetector();
+      default:
+        throw new Error(`Unsupported framework: ${framework}`);
+    }
+  }
+}

--- a/src/services/parsers/error-detectors/index.ts
+++ b/src/services/parsers/error-detectors/index.ts
@@ -4,3 +4,5 @@
 
 export { ErrorDetector, BaseErrorDetector } from './base.js';
 export { NextJsErrorDetector } from './nextjs.js';
+export { RailsErrorDetector } from './rails.js';
+export { ErrorDetectorFactory, Framework } from './factory.js';

--- a/src/services/parsers/error-detectors/index.ts
+++ b/src/services/parsers/error-detectors/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Error detectors module exports
+ */
+
+export { ErrorDetector, BaseErrorDetector } from './base.js';
+export { NextJsErrorDetector } from './nextjs.js';

--- a/src/services/parsers/error-detectors/nextjs.ts
+++ b/src/services/parsers/error-detectors/nextjs.ts
@@ -1,0 +1,52 @@
+/**
+ * Next.js error detector for Next.js applications
+ * Extends base detector with Next.js-specific error patterns
+ */
+
+import { BaseErrorDetector } from './base.js';
+
+export class NextJsErrorDetector extends BaseErrorDetector {
+  isCritical(message: string): boolean {
+    // Check parent class errors first
+    if (super.isCritical(message)) {
+      return true;
+    }
+
+    // Next.js-specific critical errors that prevent development/building
+    const criticalPatterns = [
+      // Build/compilation failures that stop the dev server
+      /Failed to compile/,                     // Compilation failures (most critical)
+      /webpack.*compilation.*failed/i,         // Webpack compilation failures
+      /Build optimization failed/,             // Build failures
+
+      // Missing dependencies/modules that prevent compilation
+      /Module not found.*Can't resolve/,       // Missing module imports
+      /Cannot resolve dependency/,             // Dependency resolution failures
+
+      // Configuration errors that prevent startup
+      /Invalid configuration/,                 // Next.js config errors
+      /Configuration error/,                   // Config parsing errors
+
+      // Build directory issues
+      /Error: ENOENT.*\.next/,                 // Missing .next directory (build artifacts)
+      /Failed to read.*\.next/,                // Can't read build artifacts
+
+      // Memory/resource issues during build
+      /JavaScript heap out of memory/,         // Out of memory during build
+      /Process out of memory/,                 // Process memory exhaustion
+
+      // SSG/SSR build-time errors (prevent build completion)
+      /Error occurred prerendering page.*build/i,  // Build-time prerender failures
+      /getStaticPaths.*error.*build/i,             // Build-time getStaticPaths errors
+      /getStaticProps.*error.*build/i,             // Build-time getStaticProps errors
+
+      // Syntax errors that prevent compilation
+      /SyntaxError.*Unexpected token/,         // JS/TS syntax errors
+      /TSError.*TypeScript error/,             // TypeScript compilation errors
+      /ESLint.*Parsing error/,                 // ESLint parsing failures
+    ];
+
+    // Check for critical patterns
+    return criticalPatterns.some(pattern => pattern.test(message));
+  }
+}

--- a/src/services/parsers/error-detectors/rails.ts
+++ b/src/services/parsers/error-detectors/rails.ts
@@ -1,0 +1,64 @@
+/**
+ * Rails error detector for Ruby on Rails applications
+ * Extends base detector with Rails-specific error patterns
+ */
+
+import { BaseErrorDetector } from './base.js';
+
+export class RailsErrorDetector extends BaseErrorDetector {
+  isCritical(message: string): boolean {
+    // Check parent class errors first
+    if (super.isCritical(message)) {
+      return true;
+    }
+    
+    // Rails-specific critical errors that prevent server startup or development
+    const criticalPatterns = [
+      // Gem and dependency errors that prevent server startup
+      /LoadError/,                       // Missing gems or required files (usually critical)
+      /Bundler::.*Error/,                // Gem dependency errors
+      /Gem::.*Error/,                    // Gem loading errors  
+      /could not find gem/i,             // Missing gem dependencies
+      /bundle.*install.*required/i,      // Bundle install needed
+      
+      // Configuration and application startup errors
+      /SyntaxError.*(?:config|application|boot)/i,        // Syntax errors in startup files
+      /NameError.*(?:config|application|boot)/i,          // Missing constants during startup
+      /LoadError.*(?:config|application|boot)/i,          // Missing files during startup
+      /Rails.*application.*failed.*initialize/i,         // Application initialization failures
+      /configuration.*error/i,                           // Rails configuration errors
+      /invalid.*configuration/i,                         // Invalid Rails config
+      
+      // Database connection errors that prevent startup
+      /ActiveRecord::ConnectionNotEstablished/,          // No database connection
+      /ActiveRecord::NoDatabaseError/,                   // Database doesn't exist
+      /PG::ConnectionBad/,               // PostgreSQL connection failures
+      /Mysql2::Error::ConnectionError/,  // MySQL connection failures
+      /Redis::.*Error/,                  // Redis connection errors (if required for startup)
+      /database.*does not exist/i,       // Database missing
+      /connection.*refused.*database/i,   // Database connection refused
+      
+      // Server startup failures
+      /Address already in use/,          // Port conflicts
+      /server.*failed.*start/i,          // General server startup failures
+      /rails.*server.*error/i,           // Rails server errors
+      /Puma.*failed.*start/i,            // Puma server startup failures
+      /Unicorn.*failed.*start/i,         // Unicorn server startup failures
+      
+      // Migration and schema errors that block development
+      /ActiveRecord::PendingMigrationError/,             // Pending migrations
+      /ActiveRecord::StatementInvalid.*migration/i,     // Migration failures
+      /database.*migration.*failed/i,                   // Migration failures
+    ];
+    
+    // Early return false for Rails warnings and runtime errors  
+    if (/DEPRECATION WARNING/i.test(message) || 
+        /asset.*not found/i.test(message) ||
+        /Precompiling assets/i.test(message)) {
+      return false;
+    }
+    
+    // Check for critical patterns
+    return criticalPatterns.some(pattern => pattern.test(message));
+  }
+}

--- a/src/services/parsers/factories.test.ts
+++ b/src/services/parsers/factories.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the factory system and ProjectDetector
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync } from 'fs';
+import { LogFormatParserFactory } from './log-parsers/factory.js';
+import { ErrorDetectorFactory } from './error-detectors/factory.js';
+import { OutputProcessorFactory } from './output-processor-factory.js';
+import { ProjectDetector } from './project-detector.js';
+import { StandardLogParser, ForemanLogParser } from './log-parsers/index.js';
+import { NextJsErrorDetector, RailsErrorDetector } from './error-detectors/index.js';
+
+// Mock fs
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+describe('ProjectDetector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should detect foreman process manager from bin/dev command', () => {
+    const result = ProjectDetector.detectProcessManager('bin/dev');
+    expect(result).toBe('foreman');
+  });
+
+  it('should detect foreman process manager from foreman command', () => {
+    const result = ProjectDetector.detectProcessManager('foreman start');
+    expect(result).toBe('foreman');
+  });
+
+  it('should detect standard process manager for npm run dev', () => {
+    const result = ProjectDetector.detectProcessManager('npm run dev');
+    expect(result).toBe('standard');
+  });
+
+  it('should detect rails framework from project files', () => {
+    vi.mocked(existsSync).mockImplementation((path) => {
+      return path === 'Gemfile';
+    });
+
+    const result = ProjectDetector.detectFramework();
+    expect(result).toBe('rails');
+  });
+
+  it('should detect rails framework from bin/dev command', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    
+    const result = ProjectDetector.detectFramework('bin/dev');
+    expect(result).toBe('rails');
+  });
+
+  it('should detect nextjs framework from project files', () => {
+    vi.mocked(existsSync).mockImplementation((path) => {
+      return path === 'next.config.js';
+    });
+
+    const result = ProjectDetector.detectFramework();
+    expect(result).toBe('nextjs');
+  });
+});
+
+describe('LogFormatParserFactory', () => {
+  it('should create ForemanLogParser', () => {
+    const parser = LogFormatParserFactory.create('foreman');
+    expect(parser).toBeInstanceOf(ForemanLogParser);
+  });
+
+  it('should create StandardLogParser', () => {
+    const parser = LogFormatParserFactory.create('standard');
+    expect(parser).toBeInstanceOf(StandardLogParser);
+  });
+});
+
+describe('ErrorDetectorFactory', () => {
+  it('should create RailsErrorDetector', () => {
+    const detector = ErrorDetectorFactory.create('rails');
+    expect(detector).toBeInstanceOf(RailsErrorDetector);
+  });
+
+  it('should create NextJsErrorDetector', () => {
+    const detector = ErrorDetectorFactory.create('nextjs');
+    expect(detector).toBeInstanceOf(NextJsErrorDetector);
+  });
+});
+
+describe('OutputProcessorFactory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should create Rails + Foreman processor for bin/dev', () => {
+    vi.mocked(existsSync).mockImplementation((path) => {
+      return path === 'Gemfile';
+    });
+
+    const processor = OutputProcessorFactory.create('bin/dev');
+    
+    expect(processor).toBeDefined();
+    expect(processor.getLogFormatParser()).toBeInstanceOf(ForemanLogParser);
+    expect(processor.getErrorDetector()).toBeInstanceOf(RailsErrorDetector);
+  });
+
+  it('should create Next.js + Standard processor for npm run dev', () => {
+    vi.mocked(existsSync).mockImplementation((path) => {
+      return path === 'next.config.js';
+    });
+
+    const processor = OutputProcessorFactory.create('npm run dev');
+    
+    expect(processor).toBeDefined();
+    expect(processor.getLogFormatParser()).toBeInstanceOf(StandardLogParser);
+    expect(processor.getErrorDetector()).toBeInstanceOf(NextJsErrorDetector);
+  });
+});

--- a/src/services/parsers/index.ts
+++ b/src/services/parsers/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Public API for the log parsers module
+ * Only exposes what external consumers need
+ */
+
+// Main output processor and types
+export {
+  OutputProcessor,
+  LogEntry,
+} from './output-processor.js';
+
+// Concrete implementations for Next.js
+export { StandardLogParser } from './log-parsers/standard.js';
+export { NextJsErrorDetector } from './error-detectors/nextjs.js';

--- a/src/services/parsers/index.ts
+++ b/src/services/parsers/index.ts
@@ -9,6 +9,9 @@ export {
   LogEntry,
 } from './output-processor.js';
 
-// Concrete implementations for Next.js
-export { StandardLogParser } from './log-parsers/standard.js';
-export { NextJsErrorDetector } from './error-detectors/nextjs.js';
+// Factory for creating processors with auto-detection
+export {
+  OutputProcessorFactory,
+  ProcessManagerOption,
+  FrameworkOption,
+} from './output-processor-factory.js';

--- a/src/services/parsers/log-parsers/base.ts
+++ b/src/services/parsers/log-parsers/base.ts
@@ -1,0 +1,27 @@
+/**
+ * Base interfaces and types for log format parsers
+ * Responsible for parsing log formats from different process managers
+ */
+
+/**
+ * Parsed log line structure after format parsing
+ */
+export interface ParsedLogLine {
+  formatted: string;     // Display format (e.g., "[WEB] Started GET /")
+  message: string;       // Raw message for error detection (e.g., "Started GET /")
+  processName?: string;  // Optional process identifier (e.g., "web", "js")
+  metadata?: Record<string, any>;  // Additional metadata from parsing
+}
+
+/**
+ * Base interface for log format parsers
+ * Responsible for parsing the structure/format of server logs (timestamps, process names, etc.)
+ */
+export interface LogFormatParser {
+  /**
+   * Parse log text into structured lines
+   * @param text Raw log text to parse
+   * @returns Array of parsed log lines with formatting and metadata
+   */
+  parse(text: string): ParsedLogLine[];
+}

--- a/src/services/parsers/log-parsers/factory.ts
+++ b/src/services/parsers/log-parsers/factory.ts
@@ -1,0 +1,33 @@
+/**
+ * Factory for creating log format parsers
+ * Pure factory - only handles object creation
+ */
+
+import { StandardLogParser, ForemanLogParser } from './index.js';
+
+/**
+ * Supported process managers for log format parsing
+ */
+export type ProcessManager = 'standard' | 'foreman';
+
+/**
+ * Simple factory for creating log format parsers
+ * No auto-detection logic - just creates the right parser for the given process manager
+ */
+export class LogFormatParserFactory {
+  /**
+   * Create a log format parser for the specified process manager
+   * @param processManager The process manager type (must be explicit)
+   * @returns A LogFormatParser instance
+   */
+  static create(processManager: ProcessManager) {
+    switch (processManager) {
+      case 'foreman':
+        return new ForemanLogParser();
+      case 'standard':
+        return new StandardLogParser();
+      default:
+        throw new Error(`Unsupported process manager: ${processManager}`);
+    }
+  }
+}

--- a/src/services/parsers/log-parsers/foreman.test.ts
+++ b/src/services/parsers/log-parsers/foreman.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for Foreman log parser
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ForemanLogParser } from './foreman.js';
+
+describe('ForemanLogParser', () => {
+  const parser = new ForemanLogParser();
+
+  it('should parse Foreman format correctly', () => {
+    const input = '14:23:45 web.1    | Started GET "/" for ::1 at 2023-01-01 14:23:45';
+    const result = parser.parse(input);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].formatted).toBe('[WEB] Started GET "/" for ::1 at 2023-01-01 14:23:45');
+    expect(result[0].message).toBe('Started GET "/" for ::1 at 2023-01-01 14:23:45');
+    expect(result[0].processName).toBe('web');
+    expect(result[0].metadata).toEqual({
+      timestamp: '14:23:45',
+      instance: 1,
+    });
+  });
+
+  it('should parse Foreman format with milliseconds', () => {
+    const input = '14:23:45.123 js.0     | webpack compiled with 1 warning';
+    const result = parser.parse(input);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].formatted).toBe('[JS] webpack compiled with 1 warning');
+    expect(result[0].message).toBe('webpack compiled with 1 warning');
+    expect(result[0].processName).toBe('js');
+    expect(result[0].metadata).toEqual({
+      timestamp: '14:23:45.123',
+      instance: 0,
+    });
+  });
+
+  it('should handle non-Foreman lines as-is', () => {
+    const input = 'Starting development server...';
+    const result = parser.parse(input);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].formatted).toBe('Starting development server...');
+    expect(result[0].message).toBe('Starting development server...');
+    expect(result[0].processName).toBeUndefined();
+    expect(result[0].metadata).toBeUndefined();
+  });
+
+  it('should handle multiple lines with mixed formats', () => {
+    const input = `Starting development server...
+14:23:45 web.1    | Rails server started on port 3000
+14:23:45 js.0     | webpack: bundle is now VALID
+Another non-Foreman line`;
+
+    const result = parser.parse(input);
+
+    expect(result).toHaveLength(4);
+    
+    // Non-Foreman line
+    expect(result[0].formatted).toBe('Starting development server...');
+    expect(result[0].processName).toBeUndefined();
+    
+    // Foreman web process
+    expect(result[1].formatted).toBe('[WEB] Rails server started on port 3000');
+    expect(result[1].processName).toBe('web');
+    
+    // Foreman js process
+    expect(result[2].formatted).toBe('[JS] webpack: bundle is now VALID');
+    expect(result[2].processName).toBe('js');
+    
+    // Non-Foreman line
+    expect(result[3].formatted).toBe('Another non-Foreman line');
+    expect(result[3].processName).toBeUndefined();
+  });
+
+  it('should handle empty input', () => {
+    const result = parser.parse('');
+    expect(result).toHaveLength(0);
+  });
+});

--- a/src/services/parsers/log-parsers/foreman.ts
+++ b/src/services/parsers/log-parsers/foreman.ts
@@ -1,0 +1,53 @@
+/**
+ * Foreman log parser for Rails bin/dev and similar tools
+ * Parses format: "HH:MM:SS process.N | message"
+ */
+
+import { LogFormatParser, ParsedLogLine } from './base.js';
+
+export class ForemanLogParser implements LogFormatParser {
+  /**
+   * Regex pattern to match Foreman/Overmind/Hivemind log format
+   * 
+   * Captures:
+   * - Group 1: Timestamp (HH:MM:SS or HH:MM:SS.mmm)
+   * - Group 2: Process name (alphanumeric with hyphens/underscores)
+   * - Group 3: Instance number (digits only)
+   * - Group 4: Message (everything after the pipe)
+   */
+  private readonly FOREMAN_REGEX = /^(\d{2}:\d{2}:\d{2}(?:\.\d{3})?)\s+([\w-]+)\.(\d+)\s+\|\s*(.*)$/;
+  
+  parse(text: string): ParsedLogLine[] {
+    if (!text || !text.trim()) {
+      return [];
+    }
+    
+    const lines = text.trim().split('\n').filter(Boolean);
+    return lines.map(line => {
+      const match = line.match(this.FOREMAN_REGEX);
+      
+      if (match) {
+        const [_, timestamp, process, instance, message] = match;
+        const processName = process.toUpperCase();
+        const formattedMessage = `[${processName}] ${message.trim()}`;
+        
+        return {
+          formatted: formattedMessage,
+          message: message.trim(),
+          processName: process,
+          metadata: {
+            timestamp,
+            instance: parseInt(instance, 10),
+          }
+        };
+      }
+      
+      // Non-Foreman lines (startup messages, errors, etc.)
+      // Keep them as-is without process prefix
+      return {
+        formatted: line,
+        message: line,
+      };
+    });
+  }
+}

--- a/src/services/parsers/log-parsers/index.ts
+++ b/src/services/parsers/log-parsers/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Log format parsers module exports
+ */
+
+export { LogFormatParser, ParsedLogLine } from './base.js';
+export { StandardLogParser } from './standard.js';

--- a/src/services/parsers/log-parsers/index.ts
+++ b/src/services/parsers/log-parsers/index.ts
@@ -4,3 +4,5 @@
 
 export { LogFormatParser, ParsedLogLine } from './base.js';
 export { StandardLogParser } from './standard.js';
+export { ForemanLogParser } from './foreman.js';
+export { LogFormatParserFactory, ProcessManager } from './factory.js';

--- a/src/services/parsers/log-parsers/standard.ts
+++ b/src/services/parsers/log-parsers/standard.ts
@@ -1,0 +1,20 @@
+/**
+ * Standard log parser for basic server logs
+ * Handles standard server logs without special process manager formatting
+ */
+
+import { LogFormatParser, ParsedLogLine } from './base.js';
+
+export class StandardLogParser implements LogFormatParser {
+  parse(text: string): ParsedLogLine[] {
+    if (!text || !text.trim()) {
+      return [];
+    }
+    
+    const lines = text.trim().split('\n').filter(Boolean);
+    return lines.map(line => ({
+      formatted: line,
+      message: line,
+    }));
+  }
+}

--- a/src/services/parsers/output-processor-factory.ts
+++ b/src/services/parsers/output-processor-factory.ts
@@ -1,0 +1,50 @@
+/**
+ * Main factory for creating output processors with auto-detection
+ * Composes log format parsers and error detectors using ProjectDetector for intelligence
+ */
+
+import { LogFormatParserFactory } from './log-parsers/factory.js';
+import { ErrorDetectorFactory } from './error-detectors/factory.js';
+import { ProjectDetector } from './project-detector.js';
+import { OutputProcessor } from './output-processor.js';
+
+import type { ProcessManager } from './log-parsers/factory.js';
+import type { Framework } from './error-detectors/factory.js';
+
+// CLI option types that include 'auto'
+export type ProcessManagerOption = ProcessManager | 'auto';
+export type FrameworkOption = Framework | 'auto';
+
+/**
+ * Main factory for creating output processors with auto-detection
+ * Handles auto-detection by delegating to ProjectDetector service
+ */
+export class OutputProcessorFactory {
+  /**
+   * Create an output processor with auto-detection
+   * @param serverCommand The command used to start the server
+   * @param processManager Optional explicit process manager (defaults to auto)
+   * @param framework Optional explicit framework (defaults to auto)
+   * @returns An OutputProcessor instance
+   */
+  static create(
+    serverCommand: string,
+    processManager: ProcessManagerOption = 'auto',
+    framework: FrameworkOption = 'auto'
+  ): OutputProcessor {
+    // Resolve process manager with fallback
+    const resolvedProcessManager: ProcessManager = processManager === 'auto'
+      ? ProjectDetector.detectProcessManager(serverCommand)  // Always returns valid ProcessManager
+      : processManager as ProcessManager;
+
+    // Resolve framework with fallback using nullish coalescing
+    const resolvedFramework: Framework = framework === 'auto'
+      ? ProjectDetector.detectFramework(serverCommand) ?? 'nextjs'  // Clean fallback pattern
+      : framework as Framework;
+
+    const logFormatParser = LogFormatParserFactory.create(resolvedProcessManager);
+    const errorDetector = ErrorDetectorFactory.create(resolvedFramework);
+
+    return new OutputProcessor(logFormatParser, errorDetector);
+  }
+}

--- a/src/services/parsers/output-processor.test.ts
+++ b/src/services/parsers/output-processor.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for the modular log parsing system with Next.js support
+ */
+
+import { describe, it, expect } from 'vitest';
+import { OutputProcessor } from './output-processor.js';
+import { StandardLogParser } from './log-parsers/standard.js';
+import { NextJsErrorDetector } from './error-detectors/nextjs.js';
+
+describe('OutputProcessor with Next.js Log Detection', () => {
+  const processor = new OutputProcessor(
+    new StandardLogParser(),
+    new NextJsErrorDetector()
+  );
+
+  it('should process standard output without errors', () => {
+    const result = processor.process('Ready - started server on 0.0.0.0:3000', false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].formatted).toBe('Ready - started server on 0.0.0.0:3000');
+    expect(result[0].isCritical).toBeUndefined();
+  });
+
+  it('should detect Next.js compilation failures as critical', () => {
+    const result = processor.process('Failed to compile', true);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].formatted).toBe('ERROR: Failed to compile');
+    expect(result[0].isCritical).toBe(true);
+    expect(result[0].rawMessage).toBe('Failed to compile');
+  });
+
+  it('should detect module resolution errors as critical', () => {
+    const result = processor.process('Module not found: Can\'t resolve \'./missing-file\'', true);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].isCritical).toBe(true);
+    expect(result[0].rawMessage).toBe('Module not found: Can\'t resolve \'./missing-file\'');
+  });
+
+  it('should detect TypeScript compilation errors as critical', () => {
+    const result = processor.process('TSError: TypeScript error in components/Button.tsx', true);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].isCritical).toBe(true);
+    expect(result[0].rawMessage).toBe('TSError: TypeScript error in components/Button.tsx');
+  });
+
+  it('should not mark Next.js warnings and non-critical errors as critical', () => {
+    // Test webpack warnings
+    const webpackResult = processor.process('webpack compiled with 1 warning', true);
+    expect(webpackResult[0].isCritical).toBeUndefined();
+
+    // Test runtime errors (don't stop dev server)
+    const runtimeResult = processor.process('Unhandled Runtime Error', true);
+    expect(runtimeResult[0].isCritical).toBeUndefined();
+
+    // Test development messages
+    const devResult = processor.process('ready - started server on 0.0.0.0:3000', true);
+    expect(devResult[0].isCritical).toBeUndefined();
+
+    // Test Fast Refresh
+    const refreshResult = processor.process('Fast Refresh had to perform a full reload', true);
+    expect(refreshResult[0].isCritical).toBeUndefined();
+  });
+
+  it('should handle multiple lines of output', () => {
+    const result = processor.process('Line 1\nLine 2\nLine 3', false);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].formatted).toBe('Line 1');
+    expect(result[1].formatted).toBe('Line 2');
+    expect(result[2].formatted).toBe('Line 3');
+  });
+
+  it('should handle empty input', () => {
+    const result = processor.process('', false);
+
+    expect(result).toHaveLength(0);
+  });
+});

--- a/src/services/parsers/output-processor.ts
+++ b/src/services/parsers/output-processor.ts
@@ -1,0 +1,71 @@
+/**
+ * Output processor that composes log format parsers and error detectors
+ * Provides the main API for processing server log output
+ */
+
+import { LogFormatParser } from './log-parsers/index.js';
+import { ErrorDetector } from './error-detectors/index.js';
+
+/**
+ * Log entry structure for processed output
+ */
+export interface LogEntry {
+  formatted: string;      // Ready-to-log formatted message
+  isCritical?: boolean;   // Optional flag for critical errors that should be shown to console
+  rawMessage?: string;    // Optional raw message for critical error display
+}
+
+/**
+ * Output processor that combines log format parsing and error detection
+ * This is the main class that should be used for processing server log output
+ */
+export class OutputProcessor {
+  constructor(
+    private logFormatParser: LogFormatParser,
+    private errorDetector: ErrorDetector
+  ) {}
+
+  /**
+   * Process log text output from the server
+   * @param text Raw log text to process
+   * @param isError Whether this is from stderr (error stream)
+   * @returns Array of processed log entries
+   */
+  process(text: string, isError: boolean = false): LogEntry[] {
+    // First, parse the log format to extract structured information
+    const parsedLines = this.logFormatParser.parse(text);
+
+    // Then, apply error detection and create log entries
+    return parsedLines.map(line => {
+      // For error output, check if it's critical
+      const isCritical = isError && this.errorDetector.isCritical(line.message);
+
+      // Build the log entry
+      const entry: LogEntry = {
+        formatted: isError ? `ERROR: ${line.formatted}` : line.formatted,
+      };
+
+      // Add critical error information if applicable
+      if (isCritical) {
+        entry.isCritical = true;
+        entry.rawMessage = line.message;
+      }
+
+      return entry;
+    });
+  }
+
+  /**
+   * Get the current log format parser
+   */
+  getLogFormatParser(): LogFormatParser {
+    return this.logFormatParser;
+  }
+
+  /**
+   * Get the current error detector
+   */
+  getErrorDetector(): ErrorDetector {
+    return this.errorDetector;
+  }
+}

--- a/src/services/parsers/project-detector.ts
+++ b/src/services/parsers/project-detector.ts
@@ -1,0 +1,89 @@
+/**
+ * Service for detecting project type and process manager from environment
+ * Handles all the filesystem checks and command analysis
+ */
+
+import { existsSync } from 'fs';
+export type Framework = 'nextjs' | 'rails';
+export type ProcessManager = 'standard' | 'foreman';
+
+// CLI options that include auto-detection
+export type FrameworkOption = Framework | 'auto';
+export type ProcessManagerOption = ProcessManager | 'auto';
+
+/**
+ * Project detection service that analyzes the environment
+ * Separated from factories to keep concerns clean
+ */
+export class ProjectDetector {
+  /**
+   * Detect the framework from the server command and project context
+   * @param serverCommand Optional server command for additional context
+   * @returns The detected framework type, or null if detection fails
+   */
+  static detectFramework(serverCommand?: string): Framework | null {
+    // Check for Rails project indicators
+    if (this.isRailsProject() || (serverCommand && this.isRailsCommand(serverCommand))) {
+      return 'rails';
+    }
+
+    // Check for Next.js project indicators
+    if (this.isNextJsProject()) {
+      return 'nextjs';
+    }
+
+    return null;
+  }
+
+  /**
+   * Detect the process manager from the server command
+   * @param serverCommand The command used to start the server
+   * @returns The detected process manager type, defaults to standard
+   */
+  static detectProcessManager(serverCommand: string): ProcessManager {
+    const command = serverCommand.toLowerCase();
+
+    // Check for Foreman-style process managers
+    if (command.includes('bin/dev') ||
+        command.includes('foreman') ||
+        command.includes('overmind') ||
+        command.includes('hivemind')) {
+      return 'foreman';
+    }
+
+    // Default to standard for most commands
+    return 'standard';
+  }
+
+  /**
+   * Check if this is a Rails project
+   * Uses multiple indicators for higher confidence
+   */
+  private static isRailsProject(): boolean {
+    return existsSync('Gemfile') ||
+           existsSync('config/application.rb') ||
+           existsSync('bin/rails');
+  }
+
+  /**
+   * Check if this is a Next.js project
+   * Uses Next.js-specific indicators to avoid false positives
+   */
+  private static isNextJsProject(): boolean {
+    return existsSync('next.config.js') ||
+           existsSync('next.config.ts') ||
+           existsSync('next.config.mjs') ||
+           existsSync('.next') ||
+           existsSync('next-env.d.ts')
+  }
+
+  /**
+   * Check if the server command indicates Rails
+   */
+  private static isRailsCommand(serverCommand: string): boolean {
+    const command = serverCommand.toLowerCase();
+    return command.includes('rails') ||
+           command.includes('bin/dev') ||
+           command.includes('bin/rails');
+  }
+}

--- a/src/services/parsers/rails-integration.test.ts
+++ b/src/services/parsers/rails-integration.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Integration tests for Rails + Foreman combination
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync } from 'fs';
+import { OutputProcessorFactory } from './output-processor-factory.js';
+
+// Mock fs
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+describe('Rails + Foreman Integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should handle Rails bin/dev output end-to-end', () => {
+    // Mock Rails project
+    vi.mocked(existsSync).mockImplementation((path) => {
+      return path === 'Gemfile';
+    });
+
+    const processor = OutputProcessorFactory.create('bin/dev');
+    
+    // Test Foreman-formatted Rails output
+    const railsOutput = `14:23:45 web.1    | Rails 7.0.0 application starting in development
+14:23:46 web.1    | => Booting Puma
+14:23:47 web.1    | => Rails 7.0.0 application starting in development on http://0.0.0.0:3000`;
+
+    const result = processor.process(railsOutput, false);
+    
+    expect(result).toHaveLength(3);
+    expect(result[0].formatted).toBe('[WEB] Rails 7.0.0 application starting in development');
+    expect(result[1].formatted).toBe('[WEB] => Booting Puma');
+    expect(result[2].formatted).toBe('[WEB] => Rails 7.0.0 application starting in development on http://0.0.0.0:3000');
+    
+    // None should be critical for stdout
+    result.forEach(entry => {
+      expect(entry.isCritical).toBeUndefined();
+    });
+  });
+
+  it('should detect Rails critical errors in Foreman format', () => {
+    vi.mocked(existsSync).mockImplementation((path) => {
+      return path === 'Gemfile';
+    });
+
+    const processor = OutputProcessorFactory.create('bin/dev');
+    
+    const railsErrorOutput = `14:23:45 web.1    | LoadError: cannot load such file -- missing_gem
+14:23:46 web.1    | ActiveRecord::ConnectionNotEstablished: No connection pool for 'ActiveRecord::Base'`;
+
+    const result = processor.process(railsErrorOutput, true);
+    
+    expect(result).toHaveLength(2);
+    
+    // LoadError should be critical
+    expect(result[0].formatted).toBe('ERROR: [WEB] LoadError: cannot load such file -- missing_gem');
+    expect(result[0].isCritical).toBe(true);
+    expect(result[0].rawMessage).toBe('LoadError: cannot load such file -- missing_gem');
+    
+    // ActiveRecord error should be critical
+    expect(result[1].formatted).toBe('ERROR: [WEB] ActiveRecord::ConnectionNotEstablished: No connection pool for \'ActiveRecord::Base\'');
+    expect(result[1].isCritical).toBe(true);
+  });
+
+  it('should ignore Rails deprecation warnings in Foreman format', () => {
+    vi.mocked(existsSync).mockImplementation((path) => {
+      return path === 'Gemfile';
+    });
+
+    const processor = OutputProcessorFactory.create('bin/dev');
+    
+    const deprecationOutput = `14:23:45 web.1    | DEPRECATION WARNING: ActiveModel::Errors#keys is deprecated`;
+
+    const result = processor.process(deprecationOutput, true);
+    
+    expect(result).toHaveLength(1);
+    expect(result[0].formatted).toBe('ERROR: [WEB] DEPRECATION WARNING: ActiveModel::Errors#keys is deprecated');
+    expect(result[0].isCritical).toBeUndefined(); // Should not be critical
+  });
+
+  it('should handle mixed Foreman and non-Foreman output', () => {
+    vi.mocked(existsSync).mockImplementation((path) => {
+      return path === 'Gemfile';
+    });
+
+    const processor = OutputProcessorFactory.create('bin/dev');
+    
+    const mixedOutput = `Starting Rails development environment...
+14:23:45 web.1    | Rails server started
+Non-Foreman error message
+14:23:46 js.0     | webpack compiled successfully`;
+
+    const result = processor.process(mixedOutput, false);
+    
+    expect(result).toHaveLength(4);
+    expect(result[0].formatted).toBe('Starting Rails development environment...');
+    expect(result[1].formatted).toBe('[WEB] Rails server started');
+    expect(result[2].formatted).toBe('Non-Foreman error message');
+    expect(result[3].formatted).toBe('[JS] webpack compiled successfully');
+  });
+});


### PR DESCRIPTION
### Motivation

This PR is an example of how we might add support for non-Next.js frameworks into d3k. 

### Changes

- Add CLI flags: `--server-command`, `--framework`, `--process-manager` with auto-detection
  - `--server-command` was previously removed from d3k, but makes sense as a way to provide an explicit "this is how to start my application" flag
  - I included basic attempts at auto-detecting the framework and process manager based on the provided `--server-command` value to try and simplify the UX
- Add ForemanLogParser
- Add RailsErrorDetector with startup/development critical error patterns
- Create ProjectDetector service for filesystem and command analysis

### Alternative Implementations

I chose to use CLI flags/options in this example, but we could also read from a configuration JSON file, as well. E.g.:

```
// .d3k.json
{
  "serverCommand": "bin/dev",
  "framework": "rails",
  "processManager": "foreman"
}
```

I think the most user-friendly choice would be to support both. The config JSON makes sense in most cases, since it is far easier just to type `d3k` and launch your app, but offering CLI flags provides utility in scenarios where a JSON file might not be available (or make less sense). 